### PR TITLE
Fix incorrect error handling when removing a user from a team

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,20 @@ local:
 compose:
 	docker-compose build && docker-compose up
 
-check: static deadcode vuln helm-lint
+check: static vuln deadcode gosec helm-lint
 
 static:
 	@echo "Running staticcheck..."
 	go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+
 vuln:
 	@echo "Running vulncheck..."
 	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
 deadcode:
 	@echo "Running deadcode..."
 	go run golang.org/x/tools/cmd/deadcode@latest -filter "pkg/client/client" -test ./...
+
 gosec:
 	@echo "Running gosec..."
 	go run github.com/securego/gosec/v2/cmd/gosec@latest --exclude G404,G101 --exclude-generated -terse ./...

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,9 +14,7 @@ services:
   swagger:
     image: swaggerapi/swagger-ui
     environment:
-      SWAGGER_JSON_URL: http://localhost:9001/api/swagger.json
-    volumes:
-      - ./swagger.json:/swagger.json
+      SWAGGER_JSON_URL: http://localhost:9010/api/swagger.json
     ports:
       - '9002:8080'
 

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -22,8 +22,9 @@ func RunHttpServer(
 	router.GET("/metrics", metrics())
 
 	srv := &http.Server{
-		Addr:    listenAddress,
-		Handler: router,
+		Addr:              listenAddress,
+		Handler:           router,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	wg, ctx := errgroup.WithContext(ctx)

--- a/pkg/client/client_integration_test.go
+++ b/pkg/client/client_integration_test.go
@@ -171,6 +171,8 @@ func TestIntegration(t *testing.T) {
 		assert.NoError(t, err)
 		err = c.DeleteUserMembership(ctx, team.Uuid, "testuser")
 		assert.NoError(t, err)
+		err = c.DeleteUserMembership(ctx, team.Uuid, "testuser")
+		assert.NoError(t, err)
 	})
 
 	t.Run("DeleteManagedUser", func(t *testing.T) {

--- a/pkg/client/user.go
+++ b/pkg/client/user.go
@@ -198,12 +198,16 @@ func (c *client) DeleteUserMembership(ctx context.Context, uuid, username string
 		if !ok {
 			return fmt.Errorf("deleting user membership: %w", err)
 		}
-		if e.StatusCode == http.StatusNotFound {
+		switch e.StatusCode {
+		case http.StatusNotFound:
 			log.Infof("user %s does not exist", username)
 			return nil
+		case http.StatusNotModified:
+			log.Infof("user %s is not a part of the team", username)
+			return nil
+		default:
+			return fmt.Errorf("deleting user membership: %w", err)
 		}
-		return fmt.Errorf("deleting user membership: %w", err)
-
 	}
 	return nil
 }


### PR DESCRIPTION
When trying to remove a user from a team that the user is **not** already a member of, the backend responds with `304 Not Modified`. The client currently treats this as an error.

Currently the client ignores `304` when trying to add a user to a team that the user is already a member of, so it makes sense to treat `304` the same way when removing memberships.

This PR adds a test for this edge case, along with a fix for the client. 
