### PR TITLE
bump: siste cloudsql proxy

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -60,7 +60,7 @@ backend:
 
   cloudProxy:
     repository: gcr.io/cloudsql-docker/gce-proxy
-    tag: 1.37.7
+    tag: 1.37.8
 
   postgresql:
     enabled: true


### PR DESCRIPTION
Ingen nevneverdige endringer, bortsett fra at man nå ved oppstart vil få en melding om å migrere til v2.

https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/main/migration-guide.md