### PR TITLE
Emit alias entry for missing GHSA ID when CVE ID is present

### DIFF
--- a/mise/tasks/check/gofix.sh
+++ b/mise/tasks/check/gofix.sh
@@ -5,12 +5,13 @@ set -euo pipefail
 echo "Running go fix..."
 
 # Produce a sorted, filename-associated checksum list for all .go files.
-# md5sum (Linux) already emits "<hash>  <file>"; md5 -r (macOS) emits the same
-# format. Sort by filename so traversal order doesn't affect the comparison.
+# md5sum (Linux) emits "<hash>  <file>"; md5 -r (macOS) emits the same format.
+# Both branches are piped through sort -k2 so traversal order never affects the
+# comparison.
 checksums() {
-  find . -name '*.go' -exec md5sum {} + 2>/dev/null \
-    || find . -name '*.go' -exec md5 -r {} + 2>/dev/null \
-    | sort -k2
+  { find . -name '*.go' -exec md5sum {} + 2>/dev/null \
+      || find . -name '*.go' -exec md5 -r {} + 2>/dev/null; \
+  } | sort -k2
 }
 
 before=$(checksums)

--- a/mise/tasks/check/gofix.sh
+++ b/mise/tasks/check/gofix.sh
@@ -4,13 +4,20 @@ set -euo pipefail
 
 echo "Running go fix..."
 
-# Snapshot checksums of all .go files before running go fix
-before=$(find . -name '*.go' -exec md5 -q {} + 2>/dev/null || find . -name '*.go' -exec md5sum {} + 2>/dev/null)
+# Produce a sorted, filename-associated checksum list for all .go files.
+# md5sum (Linux) already emits "<hash>  <file>"; md5 -r (macOS) emits the same
+# format. Sort by filename so traversal order doesn't affect the comparison.
+checksums() {
+  find . -name '*.go' -exec md5sum {} + 2>/dev/null \
+    || find . -name '*.go' -exec md5 -r {} + 2>/dev/null \
+    | sort -k2
+}
+
+before=$(checksums)
 
 go fix ./...
 
-# Snapshot checksums after
-after=$(find . -name '*.go' -exec md5 -q {} + 2>/dev/null || find . -name '*.go' -exec md5sum {} + 2>/dev/null)
+after=$(checksums)
 
 if [[ "$before" != "$after" ]]; then
   echo "go fix modified files — please run 'go fix ./...' locally and commit the changes" >&2

--- a/mise/tasks/check/gofix.sh
+++ b/mise/tasks/check/gofix.sh
@@ -3,9 +3,16 @@
 set -euo pipefail
 
 echo "Running go fix..."
+
+# Snapshot checksums of all .go files before running go fix
+before=$(find . -name '*.go' -exec md5 -q {} + 2>/dev/null || find . -name '*.go' -exec md5sum {} + 2>/dev/null)
+
 go fix ./...
 
-if ! git diff --exit-code; then
+# Snapshot checksums after
+after=$(find . -name '*.go' -exec md5 -q {} + 2>/dev/null || find . -name '*.go' -exec md5sum {} + 2>/dev/null)
+
+if [[ "$before" != "$after" ]]; then
   echo "go fix modified files — please run 'go fix ./...' locally and commit the changes" >&2
   exit 1
 fi

--- a/pkg/dependencytrack/finding.go
+++ b/pkg/dependencytrack/finding.go
@@ -258,14 +258,14 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 				if cveId == "" || cveId == vulnId {
 					continue
 				}
-			ghsaId := vulnId
-			if g, ok := alias["ghsaId"].(string); ok && g != "" {
-				ghsaId = g
-			}
-			if ghsaId == "" {
-				continue
-			}
-			references[cveId] = ghsaId
+				ghsaId := vulnId
+				if g, ok := alias["ghsaId"].(string); ok && g != "" {
+					ghsaId = g
+				}
+				if ghsaId == "" {
+					continue
+				}
+				references[cveId] = ghsaId
 			}
 		}
 	}

--- a/pkg/dependencytrack/finding.go
+++ b/pkg/dependencytrack/finding.go
@@ -257,7 +257,7 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 		for _, a := range aliases {
 			if alias, ok := a.(map[string]interface{}); ok {
 				cveId, _ := alias["cveId"].(string)
-				if cveId == "" || cveId == vulnId {
+				if cveId == "" {
 					continue
 				}
 				ghsaId, _ := alias["ghsaId"].(string)
@@ -265,10 +265,14 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 					// Only fall back to vulnId for GITHUB advisories — for other
 					// sources (NVD, OSV, etc.) vulnId is not a GHSA ID and using
 					// it would produce a meaningless CVE→CVE mapping.
-					if source != "GITHUB" || vulnId == "" {
+					if source != "GITHUB" || !strings.HasPrefix(vulnId, "GHSA-") {
 						continue
 					}
 					ghsaId = vulnId
+				}
+				// Skip self-referential mappings (cveId→ghsaId where both are the same).
+				if cveId == ghsaId {
+					continue
 				}
 				references[cveId] = ghsaId
 			}

--- a/pkg/dependencytrack/finding.go
+++ b/pkg/dependencytrack/finding.go
@@ -258,11 +258,14 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 				if cveId == "" || cveId == vulnId {
 					continue
 				}
-				ghsaId := vulnId
-				if g, ok := alias["ghsaId"].(string); ok && g != "" {
-					ghsaId = g
-				}
-				references[cveId] = ghsaId
+			ghsaId := vulnId
+			if g, ok := alias["ghsaId"].(string); ok && g != "" {
+				ghsaId = g
+			}
+			if ghsaId == "" {
+				continue
+			}
+			references[cveId] = ghsaId
 			}
 		}
 	}

--- a/pkg/dependencytrack/finding.go
+++ b/pkg/dependencytrack/finding.go
@@ -193,29 +193,31 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 		epssPercentile = &e
 	}
 
-	var link string
-	if source, ok := vulnData["source"].(string); ok {
-		switch source {
-		case "NVD":
-			link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vulnId)
-		case "GITHUB":
-			link = fmt.Sprintf("https://github.com/advisories/%s", vulnId)
-		case "UBUNTU":
-			link = fmt.Sprintf("https://ubuntu.com/security/CVE-%s", vulnId)
-		case "OSSINDEX":
-			link = fmt.Sprintf("https://ossindex.sonatype.org/vuln/%s", vulnId)
-		case "DEBIAN":
-			link = fmt.Sprintf("https://security-tracker.debian.org/tracker/%s", vulnId)
-		case "OSV":
-			link = fmt.Sprintf("https://osv.dev/vulnerability/%s", vulnId)
-		case "NPM":
-			link = fmt.Sprintf("https://www.npmjs.com/advisories/%s", vulnId)
-		case "RETIREJS":
-			link = fmt.Sprintf("https://retirejs.github.io/retire.js/%s.html", vulnId)
-		case "UNKNOWN":
-			link = fmt.Sprintf("https://security-tracker.debian.org/tracker/%s", vulnId)
+	var source string
+	if s, ok := vulnData["source"].(string); ok {
+		source = s
+	}
 
-		}
+	var link string
+	switch source {
+	case "NVD":
+		link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vulnId)
+	case "GITHUB":
+		link = fmt.Sprintf("https://github.com/advisories/%s", vulnId)
+	case "UBUNTU":
+		link = fmt.Sprintf("https://ubuntu.com/security/CVE-%s", vulnId)
+	case "OSSINDEX":
+		link = fmt.Sprintf("https://ossindex.sonatype.org/vuln/%s", vulnId)
+	case "DEBIAN":
+		link = fmt.Sprintf("https://security-tracker.debian.org/tracker/%s", vulnId)
+	case "OSV":
+		link = fmt.Sprintf("https://osv.dev/vulnerability/%s", vulnId)
+	case "NPM":
+		link = fmt.Sprintf("https://www.npmjs.com/advisories/%s", vulnId)
+	case "RETIREJS":
+		link = fmt.Sprintf("https://retirejs.github.io/retire.js/%s.html", vulnId)
+	case "UNKNOWN":
+		link = fmt.Sprintf("https://security-tracker.debian.org/tracker/%s", vulnId)
 	}
 
 	suppressed := false
@@ -258,12 +260,15 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 				if cveId == "" || cveId == vulnId {
 					continue
 				}
-				ghsaId := vulnId
-				if g, ok := alias["ghsaId"].(string); ok && g != "" {
-					ghsaId = g
-				}
+				ghsaId, _ := alias["ghsaId"].(string)
 				if ghsaId == "" {
-					continue
+					// Only fall back to vulnId for GITHUB advisories — for other
+					// sources (NVD, OSV, etc.) vulnId is not a GHSA ID and using
+					// it would produce a meaningless CVE→CVE mapping.
+					if source != "GITHUB" || vulnId == "" {
+						continue
+					}
+					ghsaId = vulnId
 				}
 				references[cveId] = ghsaId
 			}

--- a/pkg/dependencytrack/finding.go
+++ b/pkg/dependencytrack/finding.go
@@ -254,11 +254,15 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 	if aliases, ok := vulnData["aliases"].([]interface{}); ok {
 		for _, a := range aliases {
 			if alias, ok := a.(map[string]interface{}); ok {
-				if cveId, ok := alias["cveId"].(string); ok {
-					if ghsaId, ok := alias["ghsaId"].(string); ok {
-						references[cveId] = ghsaId
-					}
+				cveId, _ := alias["cveId"].(string)
+				if cveId == "" || cveId == vulnId {
+					continue
 				}
+				ghsaId := vulnId
+				if g, ok := alias["ghsaId"].(string); ok && g != "" {
+					ghsaId = g
+				}
+				references[cveId] = ghsaId
 			}
 		}
 	}

--- a/pkg/dependencytracktest/finding_test.go
+++ b/pkg/dependencytracktest/finding_test.go
@@ -42,22 +42,24 @@ func TestParseFinding(t *testing.T) {
 }
 
 func TestParseFinding_Aliases(t *testing.T) {
-	makeFinding := func(vulnId string, aliases []any) client.Finding {
+	makeFinding := func(source, vulnId string, aliases []any) client.Finding {
 		return client.Finding{
 			Component:     map[string]any{"uuid": "c1", "project": "p1", "purl": "pkg:pypi/test@1.0"},
-			Vulnerability: map[string]any{"vulnId": vulnId, "severity": "HIGH", "source": "GITHUB", "uuid": "u1", "aliases": aliases},
+			Vulnerability: map[string]any{"vulnId": vulnId, "severity": "HIGH", "source": source, "uuid": "u1", "aliases": aliases},
 			Analysis:      map[string]any{"isSuppressed": false},
 		}
 	}
 
 	tests := []struct {
 		name     string
+		source   string
 		vulnId   string
 		aliases  []any
 		wantRefs map[string]string
 	}{
 		{
 			name:   "both cveId and ghsaId present",
+			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
@@ -65,7 +67,8 @@ func TestParseFinding_Aliases(t *testing.T) {
 			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
 		},
 		{
-			name:   "cveId present but ghsaId absent — falls back to vulnId",
+			name:   "cveId present but ghsaId absent, GITHUB source — falls back to vulnId",
+			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-12797"},
@@ -73,7 +76,17 @@ func TestParseFinding_Aliases(t *testing.T) {
 			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
 		},
 		{
+			name:   "cveId present but ghsaId absent, non-GITHUB source — skipped",
+			source: "NVD",
+			vulnId: "CVE-2024-12797",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-99999"},
+			},
+			wantRefs: map[string]string{},
+		},
+		{
 			name:   "ghsaId present but cveId absent — no entry emitted",
+			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",
 			aliases: []any{
 				map[string]any{"ghsaId": "GHSA-79v4-65xg-pq4g"},
@@ -82,6 +95,7 @@ func TestParseFinding_Aliases(t *testing.T) {
 		},
 		{
 			name:   "cveId equals vulnId — self-reference skipped",
+			source: "GITHUB",
 			vulnId: "CVE-2024-12797",
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
@@ -90,6 +104,7 @@ func TestParseFinding_Aliases(t *testing.T) {
 		},
 		{
 			name:   "empty cveId — skipped",
+			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",
 			aliases: []any{
 				map[string]any{"cveId": "", "ghsaId": "GHSA-79v4-65xg-pq4g"},
@@ -98,12 +113,14 @@ func TestParseFinding_Aliases(t *testing.T) {
 		},
 		{
 			name:     "no aliases — empty references",
+			source:   "GITHUB",
 			vulnId:   "GHSA-79v4-65xg-pq4g",
 			aliases:  []any{},
 			wantRefs: map[string]string{},
 		},
 		{
 			name:   "empty vulnId with no ghsaId — skipped",
+			source: "GITHUB",
 			vulnId: "",
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-12797"},
@@ -114,7 +131,7 @@ func TestParseFinding_Aliases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v, err := dependencytrack.ParseFinding(makeFinding(tt.vulnId, tt.aliases))
+			v, err := dependencytrack.ParseFinding(makeFinding(tt.source, tt.vulnId, tt.aliases))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantRefs, v.Cve.References)
 		})

--- a/pkg/dependencytracktest/finding_test.go
+++ b/pkg/dependencytracktest/finding_test.go
@@ -102,6 +102,14 @@ func TestParseFinding_Aliases(t *testing.T) {
 			aliases:  []any{},
 			wantRefs: map[string]string{},
 		},
+		{
+			name:   "empty vulnId with no ghsaId — skipped",
+			vulnId: "",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-12797"},
+			},
+			wantRefs: map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependencytracktest/finding_test.go
+++ b/pkg/dependencytracktest/finding_test.go
@@ -85,6 +85,15 @@ func TestParseFinding_Aliases(t *testing.T) {
 			wantRefs: map[string]string{},
 		},
 		{
+			name:   "cveId present but ghsaId absent, GITHUB source with CVE vulnId — skipped",
+			source: "GITHUB",
+			vulnId: "CVE-2024-12797",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-99999"},
+			},
+			wantRefs: map[string]string{},
+		},
+		{
 			name:   "ghsaId present but cveId absent — no entry emitted",
 			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",
@@ -94,11 +103,20 @@ func TestParseFinding_Aliases(t *testing.T) {
 			wantRefs: map[string]string{},
 		},
 		{
-			name:   "cveId equals vulnId — self-reference skipped",
-			source: "GITHUB",
+			name:   "cveId equals vulnId with ghsaId present — CVE→GHSA mapping retained",
+			source: "NVD",
 			vulnId: "CVE-2024-12797",
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
+		},
+		{
+			name:   "cveId equals vulnId without ghsaId — self-reference skipped",
+			source: "GITHUB",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{
+				map[string]any{"cveId": "GHSA-79v4-65xg-pq4g"},
 			},
 			wantRefs: map[string]string{},
 		},

--- a/pkg/dependencytracktest/finding_test.go
+++ b/pkg/dependencytracktest/finding_test.go
@@ -41,6 +41,78 @@ func TestParseFinding(t *testing.T) {
 	assert.Equal(t, 0.66622, *v.EpssPercentile)
 }
 
+func TestParseFinding_Aliases(t *testing.T) {
+	makeFinding := func(vulnId string, aliases []any) client.Finding {
+		return client.Finding{
+			Component:     map[string]any{"uuid": "c1", "project": "p1", "purl": "pkg:pypi/test@1.0"},
+			Vulnerability: map[string]any{"vulnId": vulnId, "severity": "HIGH", "source": "GITHUB", "uuid": "u1", "aliases": aliases},
+			Analysis:      map[string]any{"isSuppressed": false},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		vulnId   string
+		aliases  []any
+		wantRefs map[string]string
+	}{
+		{
+			name:   "both cveId and ghsaId present",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
+		},
+		{
+			name:   "cveId present but ghsaId absent — falls back to vulnId",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-12797"},
+			},
+			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
+		},
+		{
+			name:   "ghsaId present but cveId absent — no entry emitted",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{
+				map[string]any{"ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantRefs: map[string]string{},
+		},
+		{
+			name:   "cveId equals vulnId — self-reference skipped",
+			vulnId: "CVE-2024-12797",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantRefs: map[string]string{},
+		},
+		{
+			name:   "empty cveId — skipped",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{
+				map[string]any{"cveId": "", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantRefs: map[string]string{},
+		},
+		{
+			name:     "no aliases — empty references",
+			vulnId:   "GHSA-79v4-65xg-pq4g",
+			aliases:  []any{},
+			wantRefs: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := dependencytrack.ParseFinding(makeFinding(tt.vulnId, tt.aliases))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantRefs, v.Cve.References)
+		})
+	}
+}
+
 func TestParseFinding_CvssScore(t *testing.T) {
 	ptrF := func(f float64) *float64 { return &f }
 


### PR DESCRIPTION
This pull request improves the handling and testing of vulnerability alias mappings in the Dependency-Track integration, ensuring more accurate CVE-to-GHSA references and preventing incorrect or self-referential mappings. It also enhances the reliability of the `go fix` check script by using file checksums instead of `git diff`.

**Improvements to vulnerability alias mapping logic:**

* Refined the logic in `ParseFinding` (in `pkg/dependencytrack/finding.go`) to:
  - Skip alias entries with empty `cveId` or `ghsaId`.
  - Only fall back to using `vulnId` as a `ghsaId` for GITHUB advisories with a valid GHSA format.
  - Prevent self-referential mappings where `cveId` and `ghsaId` are identical.
  - Avoid creating meaningless CVE→CVE mappings for non-GITHUB sources. [[1]](diffhunk://#diff-0a6e206d7d321c8e432ad212224d50ee402b92eb33c8ee314090ae7d92434a06L257-R277) [[2]](diffhunk://#diff-0a6e206d7d321c8e432ad212224d50ee402b92eb33c8ee314090ae7d92434a06R196-L197)

* Cleaned up unreachable code and improved source extraction for vulnerability links. [[1]](diffhunk://#diff-0a6e206d7d321c8e432ad212224d50ee402b92eb33c8ee314090ae7d92434a06L217-L218) [[2]](diffhunk://#diff-0a6e206d7d321c8e432ad212224d50ee402b92eb33c8ee314090ae7d92434a06R196-L197)

**Enhancements to testing:**

* Added comprehensive test coverage for the new alias mapping edge cases in `TestParseFinding_Aliases` in `pkg/dependencytracktest/finding_test.go`, covering scenarios like missing IDs, fallback logic, and self-references.

**Build and tooling improvements:**

* Updated `mise/tasks/check/gofix.sh` to use checksums of `.go` files before and after running `go fix`, making the check independent of Git and more robust in different environments.