### PR TITLE
Promote CVE canonical as Cve.Id for GHSA findings to fix FK violations

### DIFF
--- a/pkg/dependencytrack/finding.go
+++ b/pkg/dependencytrack/finding.go
@@ -3,6 +3,7 @@ package dependencytrack
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/nais/dependencytrack/pkg/dependencytrack/client"
@@ -279,13 +280,35 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 		}
 	}
 
+	// For GITHUB-sourced findings whose vulnId is a GHSA: promote the
+	// lexicographically first CVE canonical from the references map to be the
+	// primary Cve.Id so that v13s can satisfy the cve_alias_canonical_fkey FK
+	// constraint (the canonical must have a cve row, which is only upserted
+	// for Cve.Id). Trim references to the promoted canonical only — all other
+	// CVE keys in the map would also require a cve row that won't be upserted.
+	// Sorting ensures deterministic behaviour when a GHSA maps to multiple CVEs.
+	cveId := vulnId
+	if source == "GITHUB" && strings.HasPrefix(vulnId, "GHSA-") && len(references) > 0 {
+		canonicals := make([]string, 0, len(references))
+		for k := range references {
+			canonicals = append(canonicals, k)
+		}
+		sort.Strings(canonicals)
+		canonical := canonicals[0]
+		cveId = canonical
+		link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", canonical)
+		// Keep only the promoted canonical to avoid FK violations for the
+		// remaining alias keys which would have no corresponding cve row.
+		references = map[string]string{canonical: vulnId}
+	}
+
 	return &Vulnerability{
 		Package:         purl,
 		Suppressed:      suppressed,
 		SuppressedState: suppressedState,
 		LatestVersion:   componentLatestVersion,
 		Cve: &Cve{
-			Id:          vulnId,
+			Id:          cveId,
 			Description: desc,
 			Title:       title,
 			Link:        link,

--- a/pkg/dependencytrack/finding.go
+++ b/pkg/dependencytrack/finding.go
@@ -280,25 +280,27 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 		}
 	}
 
-	// For GITHUB findings with a GHSA vulnId: promote the CVE canonical to
-	// Cve.Id so downstream can upsert a cve row for it. Trim references to
-	// the promoted entry only — other CVE keys would also need cve rows.
-	// Sort for deterministic selection when multiple CVE aliases exist.
-	cveId := vulnId
+	// primaryId is the identifier used for Cve.Id. It starts as vulnId (which
+	// may be a GHSA ID) and is promoted to the CVE canonical when one exists.
+	primaryId := vulnId
 	if source == "GITHUB" && strings.HasPrefix(vulnId, "GHSA-") && len(references) > 0 {
 		canonicals := make([]string, 0, len(references))
 		for k := range references {
-			canonicals = append(canonicals, k)
+			if strings.HasPrefix(k, "CVE-") {
+				canonicals = append(canonicals, k)
+			}
 		}
-		sort.Strings(canonicals)
-		canonical := canonicals[0]
-		cveId = canonical
-		link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", canonical)
-		// Keep only the promoted canonical to avoid FK violations for the
-		// remaining alias keys which would have no corresponding cve row.
-		// Use the original alias value from the map rather than vulnId, in
-		// case ghsaId in the alias entry differs from vulnId.
-		references = map[string]string{canonical: references[canonical]}
+		if len(canonicals) > 0 {
+			sort.Strings(canonicals)
+			canonical := canonicals[0]
+			primaryId = canonical
+			link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", canonical)
+			// Keep only the promoted canonical to avoid FK violations for the
+			// remaining alias keys which would have no corresponding cve row.
+			// Use the original alias value from the map rather than vulnId, in
+			// case ghsaId in the alias entry differs from vulnId.
+			references = map[string]string{canonical: references[canonical]}
+		}
 	}
 
 	return &Vulnerability{
@@ -307,7 +309,7 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 		SuppressedState: suppressedState,
 		LatestVersion:   componentLatestVersion,
 		Cve: &Cve{
-			Id:          cveId,
+			Id:          primaryId,
 			Description: desc,
 			Title:       title,
 			Link:        link,

--- a/pkg/dependencytrack/finding.go
+++ b/pkg/dependencytrack/finding.go
@@ -296,7 +296,9 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 		link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", canonical)
 		// Keep only the promoted canonical to avoid FK violations for the
 		// remaining alias keys which would have no corresponding cve row.
-		references = map[string]string{canonical: vulnId}
+		// Use the original alias value from the map rather than vulnId, in
+		// case ghsaId in the alias entry differs from vulnId.
+		references = map[string]string{canonical: references[canonical]}
 	}
 
 	return &Vulnerability{

--- a/pkg/dependencytrack/finding.go
+++ b/pkg/dependencytrack/finding.go
@@ -280,13 +280,10 @@ func ParseFinding(finding client.Finding) (*Vulnerability, error) {
 		}
 	}
 
-	// For GITHUB-sourced findings whose vulnId is a GHSA: promote the
-	// lexicographically first CVE canonical from the references map to be the
-	// primary Cve.Id so that v13s can satisfy the cve_alias_canonical_fkey FK
-	// constraint (the canonical must have a cve row, which is only upserted
-	// for Cve.Id). Trim references to the promoted canonical only — all other
-	// CVE keys in the map would also require a cve row that won't be upserted.
-	// Sorting ensures deterministic behaviour when a GHSA maps to multiple CVEs.
+	// For GITHUB findings with a GHSA vulnId: promote the CVE canonical to
+	// Cve.Id so downstream can upsert a cve row for it. Trim references to
+	// the promoted entry only — other CVE keys would also need cve rows.
+	// Sort for deterministic selection when multiple CVE aliases exist.
 	cveId := vulnId
 	if source == "GITHUB" && strings.HasPrefix(vulnId, "GHSA-") && len(references) > 0 {
 		canonicals := make([]string, 0, len(references))

--- a/pkg/dependencytracktest/finding_test.go
+++ b/pkg/dependencytracktest/finding_test.go
@@ -52,13 +52,13 @@ func TestParseFinding_Aliases(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		source    string
-		vulnId    string
-		aliases   []any
-		wantId    string
-		wantLink  string
-		wantRefs  map[string]string
+		name     string
+		source   string
+		vulnId   string
+		aliases  []any
+		wantId   string
+		wantLink string
+		wantRefs map[string]string
 	}{
 		{
 			// References trimmed to promoted canonical only — remaining CVE keys
@@ -112,10 +112,10 @@ func TestParseFinding_Aliases(t *testing.T) {
 			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
 		},
 		{
-			name:   "GITHUB finding with no aliases — Cve.Id stays as GHSA",
-			source: "GITHUB",
-			vulnId: "GHSA-79v4-65xg-pq4g",
-			aliases: []any{},
+			name:     "GITHUB finding with no aliases — Cve.Id stays as GHSA",
+			source:   "GITHUB",
+			vulnId:   "GHSA-79v4-65xg-pq4g",
+			aliases:  []any{},
 			wantId:   "GHSA-79v4-65xg-pq4g",
 			wantLink: "https://github.com/advisories/GHSA-79v4-65xg-pq4g",
 			wantRefs: map[string]string{},

--- a/pkg/dependencytracktest/finding_test.go
+++ b/pkg/dependencytracktest/finding_test.go
@@ -101,6 +101,19 @@ func TestParseFinding_Aliases(t *testing.T) {
 			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
 		},
 		{
+			// ghsaId in the alias entry differs from vulnId — the trimmed
+			// references map must preserve the original ghsaId value, not vulnId.
+			name:   "GITHUB finding where ghsaId differs from vulnId — original ghsaId preserved in refs",
+			source: "GITHUB",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-different-alias"},
+			},
+			wantId:   "CVE-2024-12797",
+			wantLink: "https://nvd.nist.gov/vuln/detail/CVE-2024-12797",
+			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-different-alias"},
+		},
+		{
 			name:   "GITHUB finding with cveId only (no ghsaId) — falls back to vulnId as alias, promoted to CVE canonical",
 			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",

--- a/pkg/dependencytracktest/finding_test.go
+++ b/pkg/dependencytracktest/finding_test.go
@@ -77,6 +77,34 @@ func TestParseFinding_Aliases(t *testing.T) {
 			},
 		},
 		{
+			// Non-CVE keys in references (malformed upstream data) must not be
+			// promoted — only keys with a "CVE-" prefix are considered. If no
+			// CVE-prefixed key exists, Cve.Id stays as the GHSA vulnId.
+			name:   "GITHUB finding with only non-CVE reference key — no promotion",
+			source: "GITHUB",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{
+				map[string]any{"cveId": "GHSA-other-alias", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantId:   "GHSA-79v4-65xg-pq4g",
+			wantLink: "https://github.com/advisories/GHSA-79v4-65xg-pq4g",
+			wantRefs: map[string]string{"GHSA-other-alias": "GHSA-79v4-65xg-pq4g"},
+		},
+		{
+			// Mixed: one non-CVE key and one real CVE key — only the CVE is
+			// eligible for promotion; the non-CVE key is excluded from candidates.
+			name:   "GITHUB finding with mixed non-CVE and CVE reference keys — only CVE promoted",
+			source: "GITHUB",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{
+				map[string]any{"cveId": "GHSA-other-alias", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantId:   "CVE-2024-12797",
+			wantLink: "https://nvd.nist.gov/vuln/detail/CVE-2024-12797",
+			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
+		},
+		{
 			// GITHUB finding where vulnId is already a CVE — promotion guard
 			// (strings.HasPrefix(vulnId, "GHSA-")) prevents overwriting Cve.Id.
 			name:   "GITHUB finding with CVE vulnId and ghsaId alias — no promotion, no ref trim",
@@ -195,15 +223,6 @@ func TestParseFinding_Aliases(t *testing.T) {
 			aliases: []any{
 				map[string]any{"cveId": "", "ghsaId": "GHSA-79v4-65xg-pq4g"},
 			},
-			wantId:   "GHSA-79v4-65xg-pq4g",
-			wantLink: "https://github.com/advisories/GHSA-79v4-65xg-pq4g",
-			wantRefs: map[string]string{},
-		},
-		{
-			name:     "no aliases — empty references, Cve.Id stays as GHSA",
-			source:   "GITHUB",
-			vulnId:   "GHSA-79v4-65xg-pq4g",
-			aliases:  []any{},
 			wantId:   "GHSA-79v4-65xg-pq4g",
 			wantLink: "https://github.com/advisories/GHSA-79v4-65xg-pq4g",
 			wantRefs: map[string]string{},

--- a/pkg/dependencytracktest/finding_test.go
+++ b/pkg/dependencytracktest/finding_test.go
@@ -22,12 +22,13 @@ func TestParseFinding(t *testing.T) {
 	v, err := dependencytrack.ParseFinding(f)
 	assert.NoError(t, err)
 	assert.Equal(t, "pkg:pypi/cryptography@43.0.1", v.Package)
-	assert.Equal(t, "GHSA-79v4-65xg-pq4g", v.Cve.Id)
+	// GITHUB finding with a CVE alias: Cve.Id is promoted to the CVE canonical
+	assert.Equal(t, "CVE-2024-12797", v.Cve.Id)
 	assert.Equal(t, dependencytrack.SeverityLow, v.Cve.Severity)
 	assert.Equal(t, "17170e88-cfcb-4900-b3fb-5b0be0a071a5", v.Metadata.ProjectId)
 	assert.Equal(t, "5b009251-5efd-4703-8579-49af6cd3d0c6", v.Metadata.ComponentId)
 	assert.Equal(t, "6fa86367-6014-427e-8300-69269c16025b", v.Metadata.VulnerabilityUuid)
-	assert.Equal(t, fmt.Sprintf("https://github.com/advisories/%s", "GHSA-79v4-65xg-pq4g"), v.Cve.Link)
+	assert.Equal(t, fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", "CVE-2024-12797"), v.Cve.Link)
 	assert.Equal(t, true, v.Suppressed)
 	assert.Equal(t, "Vulnerable OpenSSL included in cryptography wheels", v.Cve.Title)
 	assert.Equal(t, "a loooong description", v.Cve.Description)
@@ -51,28 +52,83 @@ func TestParseFinding_Aliases(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		source   string
-		vulnId   string
-		aliases  []any
-		wantRefs map[string]string
+		name      string
+		source    string
+		vulnId    string
+		aliases   []any
+		wantId    string
+		wantLink  string
+		wantRefs  map[string]string
 	}{
 		{
-			name:   "both cveId and ghsaId present",
+			// References trimmed to promoted canonical only — remaining CVE keys
+			// would have no cve row and would violate cve_alias_canonical_fkey.
+			name:   "GITHUB finding with multiple CVE aliases — lexicographically first CVE wins, refs trimmed to promoted only",
+			source: "GITHUB",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-99999", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+				map[string]any{"cveId": "CVE-2024-00001", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantId:   "CVE-2024-00001",
+			wantLink: "https://nvd.nist.gov/vuln/detail/CVE-2024-00001",
+			wantRefs: map[string]string{
+				"CVE-2024-00001": "GHSA-79v4-65xg-pq4g",
+			},
+		},
+		{
+			// GITHUB finding where vulnId is already a CVE — promotion guard
+			// (strings.HasPrefix(vulnId, "GHSA-")) prevents overwriting Cve.Id.
+			name:   "GITHUB finding with CVE vulnId and ghsaId alias — no promotion, no ref trim",
+			source: "GITHUB",
+			vulnId: "CVE-2024-12797",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantId:   "CVE-2024-12797",
+			wantLink: "https://github.com/advisories/CVE-2024-12797",
+			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
+		},
+		{
+			name:   "GITHUB finding with cveId and ghsaId — promoted to CVE canonical",
 			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
 			},
+			wantId:   "CVE-2024-12797",
+			wantLink: "https://nvd.nist.gov/vuln/detail/CVE-2024-12797",
 			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
 		},
 		{
-			name:   "cveId present but ghsaId absent, GITHUB source — falls back to vulnId",
+			name:   "GITHUB finding with cveId only (no ghsaId) — falls back to vulnId as alias, promoted to CVE canonical",
 			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-12797"},
 			},
+			wantId:   "CVE-2024-12797",
+			wantLink: "https://nvd.nist.gov/vuln/detail/CVE-2024-12797",
+			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
+		},
+		{
+			name:   "GITHUB finding with no aliases — Cve.Id stays as GHSA",
+			source: "GITHUB",
+			vulnId: "GHSA-79v4-65xg-pq4g",
+			aliases: []any{},
+			wantId:   "GHSA-79v4-65xg-pq4g",
+			wantLink: "https://github.com/advisories/GHSA-79v4-65xg-pq4g",
+			wantRefs: map[string]string{},
+		},
+		{
+			name:   "NVD finding with GHSA alias — Cve.Id stays as CVE (no promotion needed)",
+			source: "NVD",
+			vulnId: "CVE-2024-12797",
+			aliases: []any{
+				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
+			},
+			wantId:   "CVE-2024-12797",
+			wantLink: "https://nvd.nist.gov/vuln/detail/CVE-2024-12797",
 			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
 		},
 		{
@@ -82,6 +138,8 @@ func TestParseFinding_Aliases(t *testing.T) {
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-99999"},
 			},
+			wantId:   "CVE-2024-12797",
+			wantLink: "https://nvd.nist.gov/vuln/detail/CVE-2024-12797",
 			wantRefs: map[string]string{},
 		},
 		{
@@ -91,33 +149,30 @@ func TestParseFinding_Aliases(t *testing.T) {
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-99999"},
 			},
+			wantId:   "CVE-2024-12797",
+			wantLink: "https://github.com/advisories/CVE-2024-12797",
 			wantRefs: map[string]string{},
 		},
 		{
-			name:   "ghsaId present but cveId absent — no entry emitted",
+			name:   "ghsaId present but cveId absent — no alias entry, Cve.Id stays as GHSA",
 			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",
 			aliases: []any{
 				map[string]any{"ghsaId": "GHSA-79v4-65xg-pq4g"},
 			},
+			wantId:   "GHSA-79v4-65xg-pq4g",
+			wantLink: "https://github.com/advisories/GHSA-79v4-65xg-pq4g",
 			wantRefs: map[string]string{},
 		},
 		{
-			name:   "cveId equals vulnId with ghsaId present — CVE→GHSA mapping retained",
-			source: "NVD",
-			vulnId: "CVE-2024-12797",
-			aliases: []any{
-				map[string]any{"cveId": "CVE-2024-12797", "ghsaId": "GHSA-79v4-65xg-pq4g"},
-			},
-			wantRefs: map[string]string{"CVE-2024-12797": "GHSA-79v4-65xg-pq4g"},
-		},
-		{
-			name:   "cveId equals vulnId without ghsaId — self-reference skipped",
+			name:   "cveId equals ghsaId — self-reference skipped, Cve.Id stays as GHSA",
 			source: "GITHUB",
 			vulnId: "GHSA-79v4-65xg-pq4g",
 			aliases: []any{
 				map[string]any{"cveId": "GHSA-79v4-65xg-pq4g"},
 			},
+			wantId:   "GHSA-79v4-65xg-pq4g",
+			wantLink: "https://github.com/advisories/GHSA-79v4-65xg-pq4g",
 			wantRefs: map[string]string{},
 		},
 		{
@@ -127,13 +182,17 @@ func TestParseFinding_Aliases(t *testing.T) {
 			aliases: []any{
 				map[string]any{"cveId": "", "ghsaId": "GHSA-79v4-65xg-pq4g"},
 			},
+			wantId:   "GHSA-79v4-65xg-pq4g",
+			wantLink: "https://github.com/advisories/GHSA-79v4-65xg-pq4g",
 			wantRefs: map[string]string{},
 		},
 		{
-			name:     "no aliases — empty references",
+			name:     "no aliases — empty references, Cve.Id stays as GHSA",
 			source:   "GITHUB",
 			vulnId:   "GHSA-79v4-65xg-pq4g",
 			aliases:  []any{},
+			wantId:   "GHSA-79v4-65xg-pq4g",
+			wantLink: "https://github.com/advisories/GHSA-79v4-65xg-pq4g",
 			wantRefs: map[string]string{},
 		},
 		{
@@ -143,6 +202,8 @@ func TestParseFinding_Aliases(t *testing.T) {
 			aliases: []any{
 				map[string]any{"cveId": "CVE-2024-12797"},
 			},
+			wantId:   "",
+			wantLink: "https://github.com/advisories/",
 			wantRefs: map[string]string{},
 		},
 	}
@@ -151,6 +212,8 @@ func TestParseFinding_Aliases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			v, err := dependencytrack.ParseFinding(makeFinding(tt.source, tt.vulnId, tt.aliases))
 			assert.NoError(t, err)
+			assert.Equal(t, tt.wantId, v.Cve.Id)
+			assert.Equal(t, tt.wantLink, v.Cve.Link)
 			assert.Equal(t, tt.wantRefs, v.Cve.References)
 		})
 	}


### PR DESCRIPTION
This pull request improves the handling of vulnerability alias promotion for GITHUB-sourced findings in the `dependencytrack` package. The main change ensures that when a GITHUB finding references multiple CVE aliases, the lexicographically first CVE is promoted to be the primary canonical identifier (`Cve.Id`), and related references are trimmed to avoid foreign key violations. The test suite is expanded and updated to cover these new behaviors comprehensively.

**Vulnerability alias handling improvements:**

* In `pkg/dependencytrack/finding.go`, added logic to promote the lexicographically first CVE alias to `Cve.Id` for GITHUB findings with a `GHSA-` vulnId, ensuring deterministic and FK-safe canonical selection. References are trimmed to only include the promoted CVE.
* Updated the link for promoted CVEs to point to the NVD page for the canonical CVE, rather than the GitHub advisory.

**Test suite enhancements:**

* Expanded and updated test cases in `pkg/dependencytracktest/finding_test.go` to verify correct promotion of CVE aliases, proper trimming of references, and accurate setting of `Cve.Id` and `Cve.Link` for various combinations of GITHUB and NVD findings with aliases. [[1]](diffhunk://#diff-bb168f35bd14e85a618ce2739cc499f9ff483e110ca1c931bcc91e17add5caf2L25-R31) [[2]](diffhunk://#diff-bb168f35bd14e85a618ce2739cc499f9ff483e110ca1c931bcc91e17add5caf2R59-R131) [[3]](diffhunk://#diff-bb168f35bd14e85a618ce2739cc499f9ff483e110ca1c931bcc91e17add5caf2R141-R142) [[4]](diffhunk://#diff-bb168f35bd14e85a618ce2739cc499f9ff483e110ca1c931bcc91e17add5caf2R152-R175) [[5]](diffhunk://#diff-bb168f35bd14e85a618ce2739cc499f9ff483e110ca1c931bcc91e17add5caf2R185-R195) [[6]](diffhunk://#diff-bb168f35bd14e85a618ce2739cc499f9ff483e110ca1c931bcc91e17add5caf2R205-R206) [[7]](diffhunk://#diff-bb168f35bd14e85a618ce2739cc499f9ff483e110ca1c931bcc91e17add5caf2R215-R216)

**Internal code maintenance:**

* Added import of the `sort` package in `pkg/dependencytrack/finding.go` to support deterministic selection of the canonical CVE alias.