### PR TITLE
ci: bump nais/fasit-deploy to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,8 +124,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: nais/fasit-deploy@v3 # ratchet:exclude
+      - uses: nais/fasit-deploy@97187355184a7f0f4b7a36a2b49a86ce02240f7b # ratchet:nais/fasit-deploy@v4.0.0
         with:
           chart: ${{ env.FEATURE_REPOSITORY }}/${{ env.NAME }}
           version: ${{ needs.helm.outputs.version }}
-          target: '{"kind": "management"}'
+          targets: |
+            [
+              { "target": { "kind": "management", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "management" } }
+            ]


### PR DESCRIPTION
v4 is a breaking rewrite of the action:

- Node 24 JS action (no helm/gcloud on runner)
- `target` (single object) → `targets` (JSON list of `{target, wait}` entries)
- Drops `skip-ci`, `global`, `all-environments`, `google_service_account`, `workload_identity_provider`
- Authenticates via GitHub OIDC to the new fasit deployment endpoint

This consumer used `skip-ci: false` (default), so the action implicitly prepended a ci-nais target. In v4 that prepend must be explicit, hence the `management:ci-nais` entry first with `wait: true`, then the broader `kind:management` fanout.

See https://github.com/nais/fasit-deploy/releases/tag/v4.0.0 for full migration notes.