### PR TITLE
fix: make BOM validation bootstrap opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,52 @@ asdf install
    - **API:** http://localhost:9001
    - **Swagger UI:** http://localhost:9002
 
+### Test BOM schema validation locally
+
+The BOM schema validation workaround can be configured in Kubernetes and locally.
+
+#### Helm / Feature configuration
+
+Use the Helm value:
+
+```yaml
+bootstrap:
+  bomValidation:
+    disabled: true
+```
+
+This value is also exposed in `charts/Feature.yaml` as:
+
+```yaml
+bootstrap.bomValidation.disabled
+```
+
+Semantics:
+
+- Unset: leave the Dependency-Track setting unchanged
+- `true`: set `bom.validation.mode=DISABLED`
+- `false`: set `bom.validation.mode=ENABLED`
+
+#### Docker Compose
+
+To test the CycloneDX 1.7 workaround locally with Docker Compose, set the bootstrap environment variable:
+
+```yaml
+# - BOM_VALIDATION_DISABLED=true
+```
+
+by uncommenting it in the `bootstrap` service in `docker-compose.yaml`, or by adding it manually, then start the stack again:
+
+```bash
+make compose
+```
+
+Notes:
+
+- Omit `BOM_VALIDATION_DISABLED` to leave the Dependency-Track setting unchanged
+- Set `BOM_VALIDATION_DISABLED=true` to set `bom.validation.mode=DISABLED`
+- Set `BOM_VALIDATION_DISABLED=false` to set `bom.validation.mode=ENABLED`
+
 ### Test Users
 
 The `users.yaml` file contains pre-configured users for automated testing. You can modify this file to add or update test users as needed.

--- a/charts/Feature.yaml
+++ b/charts/Feature.yaml
@@ -86,6 +86,10 @@ values:
     displayName: Bootstrap frontend base url
     computed:
       template: '"https://salsa.{{.Tenant.Name}}.cloud.nais.io"'
+  bootstrap.bomValidation.disabled:
+    displayName: Bootstrap disable BOM schema validation
+    config:
+      type: bool
   bootstrap.github.advisory_mirroring_token:
     displayName: Bootstrap GitHub advisory mirroring token
     config:

--- a/charts/templates/bootstrap.yaml
+++ b/charts/templates/bootstrap.yaml
@@ -52,6 +52,10 @@ spec:
               value: "{{ .Values.bootstrap.logLevel }}"
             - name: BASE_URL
               value: "{{ .Values.bootstrap.baseUrl }}"
+          {{- if ne .Values.bootstrap.bomValidation.disabled nil }}
+            - name: BOM_VALIDATION_DISABLED
+              value: "{{ .Values.bootstrap.bomValidation.disabled }}"
+          {{- end }}
             - name: GOOGLE_OSV_ENABLED
               value: "{{ .Values.bootstrap.google.osv_enabled }}"
             - name: FRONTEND_BASE_URL

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -8,6 +8,8 @@ bootstrap:
     tag: yolo
   logLevel: INFO
   baseUrl: http://dependencytrack-backend:8080/api
+  bomValidation:
+    disabled:
   frontendBaseUrl:
   defaultAdminPassword: admin
   adminPassword: todo

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -19,25 +19,27 @@ var cfg = &Config{
 }
 
 type Config struct {
-	AdminPassword        string `json:"admin-password"`
-	FrontendBaseUrl      string `json:"frontend-base-url"`
-	BaseUrl              string `json:"base-url"`
-	DefaultAdminPassword string `json:"default-admin-password"`
-	LogLevel             string `json:"log-level"`
-	UsersFile            string `json:"users-file"`
-	GithubAdvisoryToken  string `json:"github-advisory-token"`
-	GoogleOSVEnabled     bool   `json:"google-osv-enabled"`
-	TrivyApiToken        string `json:"trivy-token"`
-	TrivyBaseURL         string `json:"trivy-base-url"`
-	TrivyIgnoreUnfixed   bool   `json:"trivy-ignore-unfixed"`
-	OssIndexApiUsername  string `json:"oss-index-api-username"`
-	OssIndexApiToken     string `json:"oss-index-api-token"`
+	AdminPassword         string `json:"admin-password"`
+	FrontendBaseUrl       string `json:"frontend-base-url"`
+	BaseUrl               string `json:"base-url"`
+	BomValidationDisabled string `json:"bom-validation-disabled"`
+	DefaultAdminPassword  string `json:"default-admin-password"`
+	LogLevel              string `json:"log-level"`
+	UsersFile             string `json:"users-file"`
+	GithubAdvisoryToken   string `json:"github-advisory-token"`
+	GoogleOSVEnabled      bool   `json:"google-osv-enabled"`
+	TrivyApiToken         string `json:"trivy-token"`
+	TrivyBaseURL          string `json:"trivy-base-url"`
+	TrivyIgnoreUnfixed    bool   `json:"trivy-ignore-unfixed"`
+	OssIndexApiUsername   string `json:"oss-index-api-username"`
+	OssIndexApiToken      string `json:"oss-index-api-token"`
 }
 
 func init() {
 	flag.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "which log level to use, default 'info'")
 	flag.StringVar(&cfg.FrontendBaseUrl, "frontend-base-url", "http://localhost:9000", "frontend base url")
 	flag.StringVar(&cfg.BaseUrl, "base-url", "http://localhost:9001", "base url of dependencytrack")
+	flag.StringVar(&cfg.BomValidationDisabled, "bom-validation-disabled", cfg.BomValidationDisabled, "disable Dependency-Track BOM schema validation when explicitly set to true or false")
 	flag.StringVar(&cfg.DefaultAdminPassword, "default-admin-password", "admin", "default admin password")
 	flag.StringVar(&cfg.AdminPassword, "admin-password", cfg.AdminPassword, "new admin password")
 	flag.StringVar(&cfg.GithubAdvisoryToken, "github-advisory-token", cfg.GithubAdvisoryToken, "github advisory mirroring token")
@@ -228,6 +230,23 @@ func main() {
 			}
 		}
 
+		switch *prop.PropertyName {
+		case "bom.validation.mode":
+			bomValidationMode, ok := resolveBomValidationMode(cfg.BomValidationDisabled)
+			if !ok && cfg.BomValidationDisabled != "" {
+				log.Warnf("invalid BOM_VALIDATION_DISABLED value %q, expected true or false; leaving bom validation mode unchanged", cfg.BomValidationDisabled)
+			}
+			if ok {
+				if isAlreadySet(prop.PropertyValue, bomValidationMode) {
+					log.Infof("bom validation mode already set to %s", bomValidationMode)
+					continue
+				}
+				prop.PropertyValue = &bomValidationMode
+				cp = append(cp, prop)
+				log.Infof("updated: bom validation mode to %s", bomValidationMode)
+			}
+		}
+
 		if cfg.OssIndexApiUsername == "" || cfg.OssIndexApiToken == "" {
 			switch *prop.PropertyName {
 			case "ossindex.enabled":
@@ -313,4 +332,20 @@ func isAlreadySet(config *string, inputValue string) bool {
 		return false
 	}
 	return strings.EqualFold(*config, inputValue)
+}
+
+func resolveBomValidationMode(disabled string) (string, bool) {
+	if disabled == "" {
+		return "", false
+	}
+
+	if strings.EqualFold(disabled, "true") {
+		return "DISABLED", true
+	}
+
+	if strings.EqualFold(disabled, "false") {
+		return "ENABLED", true
+	}
+
+	return "", false
 }

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -39,7 +39,7 @@ func init() {
 	flag.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "which log level to use, default 'info'")
 	flag.StringVar(&cfg.FrontendBaseUrl, "frontend-base-url", "http://localhost:9000", "frontend base url")
 	flag.StringVar(&cfg.BaseUrl, "base-url", "http://localhost:9001", "base url of dependencytrack")
-	flag.StringVar(&cfg.BomValidationDisabled, "bom-validation-disabled", cfg.BomValidationDisabled, "disable Dependency-Track BOM schema validation when explicitly set to true or false")
+	flag.StringVar(&cfg.BomValidationDisabled, "bom-validation-disabled", cfg.BomValidationDisabled, "set Dependency-Track BOM schema validation mode when explicitly set to true (disable) or false (enable); omit to leave unchanged")
 	flag.StringVar(&cfg.DefaultAdminPassword, "default-admin-password", "admin", "default admin password")
 	flag.StringVar(&cfg.AdminPassword, "admin-password", cfg.AdminPassword, "new admin password")
 	flag.StringVar(&cfg.GithubAdvisoryToken, "github-advisory-token", cfg.GithubAdvisoryToken, "github advisory mirroring token")
@@ -234,7 +234,7 @@ func main() {
 		case "bom.validation.mode":
 			bomValidationMode, ok := resolveBomValidationMode(cfg.BomValidationDisabled)
 			if !ok && cfg.BomValidationDisabled != "" {
-				log.Warnf("invalid BOM_VALIDATION_DISABLED value %q, expected true or false; leaving bom validation mode unchanged", cfg.BomValidationDisabled)
+				log.Warnf("invalid BOM_VALIDATION_DISABLED / --bom-validation-disabled value %q, expected true or false; leaving bom validation mode unchanged", cfg.BomValidationDisabled)
 			}
 			if ok {
 				if isAlreadySet(prop.PropertyValue, bomValidationMode) {
@@ -335,6 +335,8 @@ func isAlreadySet(config *string, inputValue string) bool {
 }
 
 func resolveBomValidationMode(disabled string) (string, bool) {
+	disabled = strings.TrimSpace(disabled)
+
 	if disabled == "" {
 		return "", false
 	}

--- a/cmd/bootstrap/main_test.go
+++ b/cmd/bootstrap/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+func TestResolveBomValidationMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		disabled    string
+		wantMode    string
+		wantResolve bool
+	}{
+		{
+			name:        "unset does not resolve",
+			disabled:    "",
+			wantMode:    "",
+			wantResolve: false,
+		},
+		{
+			name:        "true disables validation",
+			disabled:    "true",
+			wantMode:    "DISABLED",
+			wantResolve: true,
+		},
+		{
+			name:        "false enables validation",
+			disabled:    "false",
+			wantMode:    "ENABLED",
+			wantResolve: true,
+		},
+		{
+			name:        "case insensitive true disables validation",
+			disabled:    "TRUE",
+			wantMode:    "DISABLED",
+			wantResolve: true,
+		},
+		{
+			name:        "unexpected value does not resolve",
+			disabled:    "maybe",
+			wantMode:    "",
+			wantResolve: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMode, gotResolve := resolveBomValidationMode(tt.disabled)
+			if gotMode != tt.wantMode {
+				t.Fatalf("resolveBomValidationMode(%q) mode = %q, want %q", tt.disabled, gotMode, tt.wantMode)
+			}
+			if gotResolve != tt.wantResolve {
+				t.Fatalf("resolveBomValidationMode(%q) resolved = %v, want %v", tt.disabled, gotResolve, tt.wantResolve)
+			}
+		})
+	}
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,6 +61,9 @@ services:
       - BASE_URL=http://dtrack-apiserver:8080/
       - DEFAULT_ADMIN_PASSWORD=admin
       - ADMIN_PASSWORD=yolo
+      # Optional: set to true to disable BOM schema validation, or false to force enable it.
+      # Omit entirely to leave the Dependency-Track setting unchanged.
+      # - BOM_VALIDATION_DISABLED=true
       - TRIVY_API_TOKEN=my-token
       - USERS_FILE=users.yaml
       - TRIVY_BASE_URL=http://trivy:4005


### PR DESCRIPTION
## Summary
- add opt-in bootstrap support for configuring Dependency-Track BOM validation mode
- document Helm/Feature and Docker Compose configuration for the workaround
- add tests for BOM validation mode resolution and invalid values

## Testing
- rtk go test ./cmd/bootstrap